### PR TITLE
Parallelize `sort` process

### DIFF
--- a/Cecret.nf
+++ b/Cecret.nf
@@ -414,7 +414,7 @@ process sort {
     date | tee -a $log_file $err_file > /dev/null
     samtools --version >> $log_file
 
-    samtools sort !{sam} 2>> $err_file | \
+    samtools sort -@ !{task.cpus} !{sam} 2>> $err_file | \
       samtools view -F 4 -o aligned/!{sample}.sorted.bam 2>> $err_file >> $log_file
 
     # indexing the bams


### PR DESCRIPTION
Previously, I had to reduce the number of reserved CPUs for this step,
as the command did not use every allocated core. A cursory look on
GitHub revealed the `-@` option, which is documented as "threads" in the
samtools manual.
