### PR TITLE
Quoting the clade name prevents a broken downstream summary.csv file

### DIFF
--- a/Cecret.nf
+++ b/Cecret.nf
@@ -1388,7 +1388,7 @@ process summary {
     result="$result,!{pangolin_lineage},!{pangolin_status}"
 
     header="$header,nextclade_clade"
-    result="$result,\"!{nextclade_clade}\""
+    result="$result,\\\"!{nextclade_clade}\\\""
 
     header="$header,fastqc_raw_reads_1,fastqc_raw_reads_2"
     result="$result,!{raw_1},!{raw_2}"

--- a/Cecret.nf
+++ b/Cecret.nf
@@ -1388,7 +1388,7 @@ process summary {
     result="$result,!{pangolin_lineage},!{pangolin_status}"
 
     header="$header,nextclade_clade"
-    result="$result,!{nextclade_clade}"
+    result="$result,\"!{nextclade_clade}\""
 
     header="$header,fastqc_raw_reads_1,fastqc_raw_reads_2"
     result="$result,!{raw_1},!{raw_2}"


### PR DESCRIPTION
With this fix, the "summary.csv" file is no longer broken by the comma-containing new clade names like "20I (Alpha, V1)".