### PR TITLE
Update 20231205

### DIFF
--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -2,7 +2,7 @@ process artic {
     tag        "${sample}"
     label      "process_high"
     publishDir "${params.outdir}", mode: 'copy'
-    container  'quay.io/uphl/artic:1.2.4-1.11.1'
+    container  'quay.io/uphl/artic:1.2.4-1.11.2-2023-12-05'
   
     //#UPHLICA maxForks      10
     //#UPHLICA errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}

--- a/modules/freyja.nf
+++ b/modules/freyja.nf
@@ -3,7 +3,7 @@ process freyja_variants {
   label         "process_medium"
   //errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}
   publishDir    "${params.outdir}", mode: 'copy'
-  container     'quay.io/uphl/freyja:1.4.7-2023-11-28'
+  container     'quay.io/uphl/freyja:1.4.7-2023-12-05'
 
   //#UPHLICA maxForks 10
   //#UPHLICA pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-xlarge'
@@ -44,7 +44,7 @@ process freyja_demix {
   label         "process_medium"
   //errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}
   publishDir    "${params.outdir}", mode: 'copy'
-  container     'quay.io/uphl/freyja:1.4.7-2023-11-28'
+  container     'quay.io/uphl/freyja:1.4.7-2023-12-05'
 
   //#UPHLICA maxForks 10
   //#UPHLICA pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-xlarge'
@@ -85,7 +85,7 @@ process freyja_boot {
   label         "process_medium"
   //errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}
   publishDir    "${params.outdir}", mode: 'copy'
-  container     'quay.io/uphl/freyja:1.4.7-2023-11-28'
+  container     'quay.io/uphl/freyja:1.4.7-2023-12-05'
 
   //#UPHLICA maxForks 10
   //#UPHLICA pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-xlarge'
@@ -124,7 +124,7 @@ process freyja_aggregate {
   tag        "Aggregating results from freyja"
   label      "process_single"
   publishDir "${params.outdir}", mode: 'copy'
-  container  'quay.io/uphl/freyja:1.4.7-2023-11-28'
+  container  'quay.io/uphl/freyja:1.4.7-2023-12-05'
 
   //#UPHLICA maxForks 10
   //#UPHLICA errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}

--- a/modules/heatcluster.nf
+++ b/modules/heatcluster.nf
@@ -1,7 +1,7 @@
 process heatcluster {
   tag           "HeatCluster"
   publishDir    params.outdir, mode: 'copy'
-  container     'quay.io/uphl/heatcluster:0.4.12-2023-11-15'
+  container     'quay.io/uphl/heatcluster:0.4.13-2023-12-05'
   maxForks      10
   //#UPHLICA errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}
   //#UPHLICA pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-medium'

--- a/modules/minimap2.nf
+++ b/modules/minimap2.nf
@@ -2,7 +2,7 @@ process minimap2 {
   tag         "${sample}"
   label       "process_high"
   publishDir  path: "${params.outdir}", mode: 'copy', pattern: 'logs/*/*log'
-  container   'staphb/minimap2:2.25'
+  container   'staphb/minimap2:2.26'
 
   //#UPHLICA maxForks 10
   //#UPHLICA errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}

--- a/modules/pangolin.nf
+++ b/modules/pangolin.nf
@@ -2,7 +2,7 @@ process pangolin {
   tag        "SARS-CoV-2 lineage Determination"
   label      "process_medium"
   publishDir "${params.outdir}", mode: 'copy'
-  container  'staphb/pangolin:4.3.1-pdata-1.23.1'
+  container  'staphb/pangolin:4.3.1-pdata-1.23.1-1'
 
   //#UPHLICA maxForks      10
   //#UPHLICA errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}
@@ -24,7 +24,7 @@ process pangolin {
 
   shell:
   '''
-    mkdir -p temp pangolin logs/!{task.process}
+    mkdir -p pangolin logs/!{task.process}
     log=logs/!{task.process}/!{task.process}.!{workflow.sessionId}.log
 
     date > $log
@@ -38,10 +38,10 @@ process pangolin {
     pangolin !{params.pangolin_options} \
       --threads !{task.cpus} \
       --outdir pangolin \
-      --tempdir temp \
       --verbose \
       ultimate_fasta.fasta \
       | tee -a $log
+
     cp ultimate_fasta.fasta pangolin/combined.fasta
   '''
 }

--- a/modules/phytreeviz.nf
+++ b/modules/phytreeviz.nf
@@ -2,7 +2,7 @@ process phytreeviz {
   tag           "Tree visualization"
   label         "maxcpus"
   publishDir    params.outdir, mode: 'copy'
-  container     'quay.io/uphl/phytreeviz:0.1.0-2023-11-15'
+  container     'staphb/phytreeviz:0.1.0'
   maxForks      10
   //#UPHLICA errorStrategy { task.attempt < 2 ? 'retry' : 'ignore'}
   //#UPHLICA pod annotation: 'scheduler.illumina.com/presetSize', value: 'standard-xlarge'

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   name              = 'Cecret'
   author            = 'Erin Young'
   homePage          = 'https://github.com/UPHL-BioNGS/Cecret'
-  version           = 'v3.10.20231128'
+  version           = 'v3.10.20231205'
   defaultBranch     = 'master'
   recurseSubmodules = false
   description       = 'Reference-based consensus creation'


### PR DESCRIPTION
Version bumps mostly.

Addresses https://github.com/UPHL-BioNGS/Cecret/issues/263

_Should_ fix the pangolin issues with writing to a temp drive.
