### PR TITLE
Update 3.26.25079

### DIFF
--- a/conf/uphl.config
+++ b/conf/uphl.config
@@ -2,4 +2,4 @@ docker.enabled          = true
 docker.runOptions       = '-u $(id -u):$(id -g)'
 
 params.kraken2         = true
-params.kraken2_db      = '/Volumes/IDGenomics_NAS/Data/kraken2_db/h+v'
+params.kraken2_db      = '/Volumes/NGS/Data/kraken2_db/k2_standard_08gb_20241228/'

--- a/modules/local/bbnorm.nf
+++ b/modules/local/bbnorm.nf
@@ -1,7 +1,7 @@
 process BBNORM {
     tag           "${meta.id}"
     label         'process_medium'
-    container     'staphb/bbtools:39.13'
+    container     'staphb/bbtools:39.16'
 
     input:
     tuple val(meta), file(reads)

--- a/modules/local/datasets.nf
+++ b/modules/local/datasets.nf
@@ -2,7 +2,7 @@ process DATASETS {
   tag           "${accession}"
   // because there's no way to specify threads
   label         "process_low"
-  container     'staphb/ncbi-datasets:16.38.1'
+  container     'staphb/ncbi-datasets:16.41.0'
 
   input:
   val(accession)

--- a/modules/local/freyja.nf
+++ b/modules/local/freyja.nf
@@ -1,7 +1,7 @@
 process FREYJA {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/freyja:1.5.3-03_07_2025-01-59-2025-03-10'
+  container     'staphb/freyja:1.5.3-03_17_2025-01-48-2025-03-17'
 
   input:
   tuple val(meta), file(bam), file(reference_genome)
@@ -51,7 +51,7 @@ process FREYJA {
 process FREYJA_AGGREGATE {
   tag        "Aggregating results from freyja"
   label      "process_single"
-  container  'staphb/freyja:1.5.3-03_07_2025-01-59-2025-03-10'
+  container  'staphb/freyja:1.5.3-03_17_2025-01-48-2025-03-17'
 
   input:
   file(demix)

--- a/modules/local/iqtree2.nf
+++ b/modules/local/iqtree2.nf
@@ -1,7 +1,7 @@
 process IQTREE2 {
   tag        "Creating phylogenetic tree with iqtree"
   label      "process_high"
-  container  'staphb/iqtree2:2.3.6'
+  container  'staphb/iqtree2:2.4.0'
 
   input:
   file(msa)

--- a/modules/local/ivar.nf
+++ b/modules/local/ivar.nf
@@ -1,7 +1,7 @@
 process IVAR_CONSENSUS {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/ivar:1.4.3'
+  container     'staphb/ivar:1.4.4'
 
   input:
   tuple val(meta), file(bam), file(reference_genome)
@@ -50,7 +50,7 @@ process IVAR_CONSENSUS {
 process IVAR_VARIANTS {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/ivar:1.4.3'
+  container     'staphb/ivar:1.4.4'
 
   input:
   tuple val(meta), file(bam), file(reference_genome), file(gff_file)
@@ -109,7 +109,7 @@ process IVAR_VARIANTS {
 process IVAR_TRIM {
   tag        "${meta.id}"
   label      "process_medium"
-  container  'staphb/ivar:1.4.3'
+  container  'staphb/ivar:1.4.4'
 
   input:
   tuple val(meta), file(bam), file(primer_bed)

--- a/modules/local/local.nf
+++ b/modules/local/local.nf
@@ -1,6 +1,6 @@
 process DOWNLOAD_FASTQ {
   tag        "${sra}"
-  container  'staphb/multiqc:1.19'
+  container  'staphb/multiqc:1.27.1'
   label      "process_single"
 
   input:

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -1,7 +1,7 @@
 process MULTIQC {
   tag        "multiqc"
   label      "process_single"
-  container  'staphb/multiqc:1.26'
+  container  'staphb/multiqc:1.27.1'
 
   input:
   file(input)

--- a/nextflow.config
+++ b/nextflow.config
@@ -274,7 +274,7 @@ manifest {
   name              = 'UPHL-BioNGS/Cecret'
   author            = 'Erin Young'
   homePage          = 'https://github.com/UPHL-BioNGS/Cecret'
-  version           = 'v3.26.25071'
+  version           = 'v3.26.25079'
   defaultBranch     = 'master'
   recurseSubmodules = false
   description       = 'Reference-based consensus creation'


### PR DESCRIPTION
Update to 3.26.25079
- Update bbnorm to 39.16
- Update datasets to 16.41.0
- Update freyja to 1.5.3-03_17_2025-01-48-2025-03-17
- Update iqtree2 to 2.4.0
- Update ivar to 1.4.4
- Update multiqc to 1.27.1
- Update local download_fastq to multiqc version 1.27.1