### PR TITLE
Update 20250902

### DIFF
--- a/conf/latest.config
+++ b/conf/latest.config
@@ -18,7 +18,7 @@ process {
         container = 'staphb/ncbi-datasets:latest'
     }
     withName: ENA {
-        container = 'staphb/ena:latest'
+        container = 'staphb/enabrowsertools:latest'
     }
     withName: FASTP {
         container = 'staphb/fastp:latest'

--- a/modules/local/aci/main.nf
+++ b/modules/local/aci/main.nf
@@ -1,7 +1,7 @@
 process ACI {
     tag        "${meta.id}"
     label      "process_high"
-    container  'staphb/aci:1.4.20240116'
+    container  'staphb/aci:1.15.250702'
 
     input:
     tuple val(meta), file(bam), file(bed)

--- a/modules/local/artic/main.nf
+++ b/modules/local/artic/main.nf
@@ -1,7 +1,7 @@
 process ARTIC {
     tag        "${meta.id}"
     label      "process_high"
-    container  'staphb/artic:1.7.3'
+    container  'staphb/artic:1.7.5'
 
     input:
     tuple val(meta), file(fastq), file(reference), file(bed)
@@ -61,7 +61,7 @@ process ARTIC {
 
 process ARTIC_FILTER {
     tag        "${meta.id}"
-    container  'staphb/artic:1.7.3'
+    container  'staphb/artic:1.7.5'
     label      "process_low"
 
     input:

--- a/modules/local/bbnorm/main.nf
+++ b/modules/local/bbnorm/main.nf
@@ -1,7 +1,7 @@
 process BBNORM {
     tag           "${meta.id}"
     label         'process_medium'
-    container     'staphb/bbtools:39.26'
+    container     'staphb/bbtools:39.33'
 
     input:
     tuple val(meta), file(reads)

--- a/modules/local/datasets/main.nf
+++ b/modules/local/datasets/main.nf
@@ -2,7 +2,7 @@ process DATASETS {
   tag           "${accession}"
   // because there's no way to specify threads
   label         "process_low"
-  container     'staphb/ncbi-datasets:18.0.2'
+  container     'staphb/ncbi-datasets:18.5.0'
 
   input:
   val(accession)

--- a/modules/local/freyja/main.nf
+++ b/modules/local/freyja/main.nf
@@ -1,7 +1,7 @@
 process FREYJA {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/freyja:2.0.0-08_25_2025-00-35-2025-08-25'
+  container     'staphb/freyja:2.0.0-09_01_2025-00-38-2025-09-01'
 
   input:
   tuple val(meta), file(bam), file(reference_genome)
@@ -51,7 +51,7 @@ process FREYJA {
 process FREYJA_AGGREGATE {
   tag        "Aggregating results from freyja"
   label      "process_single"
-  container  'staphb/freyja:2.0.0-08_25_2025-00-35-2025-08-25'
+  container  'staphb/freyja:2.0.0-09_01_2025-00-38-2025-09-01'
 
   input:
   file(demix)

--- a/modules/local/igvreports/main.nf
+++ b/modules/local/igvreports/main.nf
@@ -1,7 +1,7 @@
 process IGV_REPORTS {
   tag         "${meta.id}"
   label       "process_high"
-  container   'staphb/igv-reports:1.12.0'
+  container   'staphb/igv-reports:1.15.1'
 
   input:
   tuple val(meta), file(vcf), file(bam), file(bai), file(reference_genome)

--- a/modules/local/minimap2/main.nf
+++ b/modules/local/minimap2/main.nf
@@ -1,7 +1,7 @@
 process MINIMAP2 {
   tag         "${meta.id}"
   label       "process_high"
-  container   'staphb/minimap2:2.29'
+  container   'staphb/minimap2:2.30'
 
   input:
   tuple val(meta), file(reads), file(reference_genome)

--- a/modules/local/multiqc/main.nf
+++ b/modules/local/multiqc/main.nf
@@ -1,7 +1,7 @@
 process MULTIQC {
   tag        "multiqc"
   label      "process_single"
-  container  'staphb/multiqc:1.28'
+  container  'staphb/multiqc:1.30'
 
   input:
   file(input)

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,7 +58,7 @@ params {
 
     //# parameters for processes with their default values
     aci_options                          = ''
-    artic_options                        = '--normalise 200 --model ont --model-dir /opt/conda/envs/artic/bin/models/'
+    artic_options                        = '--normalise 200 --model r1041_e82_400bps_sup_v500 --model-dir /opt/conda/envs/artic/bin/models/'
     artic_read_filtering_options         = '--min-length 400 --max-length 700'
     bbnorm_options                       = 'target=200 min=5'
     bcftools_variants_options            = ''

--- a/nextflow.config
+++ b/nextflow.config
@@ -281,7 +281,7 @@ manifest {
   mainScript        = 'main.nf'
   defaultBranch     = 'master'
   nextflowVersion   = '>=24.04.4'
-  version           = 'v3.54.25238'
+  version           = 'v3.54.25245'
   description       = 'Reference-based consensus creation'
   doi               = ''
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -363,7 +363,7 @@
                 },
                 "artic_options": {
                     "type": "string",
-                    "default": "--normalise 200 --model ont --model-dir /opt/conda/envs/artic/bin/models/",
+                    "default": "--normalise 200 --model r1041_e82_400bps_sup_v500 --model-dir /opt/conda/envs/artic/bin/models/",
                     "hidden": true,
                     "description": "Options for process"
                 },


### PR DESCRIPTION
Closes https://github.com/UPHL-BioNGS/Cecret/issues/485 and https://github.com/UPHL-BioNGS/Cecret/issues/484

Update 3.54.25245:
- fixed ena container name in latest config file
- Update aci to 1.15.250702
- Update artic to 1.7.5
- Update bbnorm to 39.33
- Update datasets to 18.5.0
- Update igvreports
- Update minimap2 to 2.30
- Update multiqc to 1.30
- Update freyja to 2.0.0-09_01_2025-00-38-2025-09-01