### PR TITLE
3.72.26112

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ WIKI can be found at [https://github.com/UPHL-BioNGS/Cecret/wiki](https://github
 ## Usage
 
 ```bash
+nextflow run UPHL-BioNGS/Cecret -profile docker,test
+```
+
+### Help
+
+```bash
 $ nextflow run UPHL-BioNGS/Grandeur --help
 
  N E X T F L O W   ~  version 25.10.0
@@ -114,6 +120,8 @@ Workflow Components
 
 ------------------------------------------------------
 ```
+
+### Using a Sample Sheet
 
 Cecret can also use a sample sheet for input with the sample name and reads separated by commas. The header must be `sample,fastq_1,fastq_2`. The general rule is the identifier for the file(s), the file locations, and the type if not paired-end fastq files.
 

--- a/modules/local/bbnorm/main.nf
+++ b/modules/local/bbnorm/main.nf
@@ -1,7 +1,7 @@
 process BBNORM {
     tag           "${meta.id}"
     label         'process_medium'
-    container     'staphb/bbtools:39.77'
+    container     'staphb/bbtools:39.81b'
 
 
     input:

--- a/modules/local/bcftools/main.nf
+++ b/modules/local/bcftools/main.nf
@@ -1,6 +1,6 @@
 process BCFTOOLS {
   tag           "${meta.id}"
-  container     'staphb/bcftools:1.23'
+  container     'staphb/bcftools:1.23.1'
   label         'process_single'
 
   input:

--- a/modules/local/datasets/main.nf
+++ b/modules/local/datasets/main.nf
@@ -2,7 +2,7 @@ process DATASETS {
   tag           "${accession}"
   // because there's no way to specify threads
   label         "process_low"
-  container     'staphb/ncbi-datasets:18.18.0'
+  container     'staphb/ncbi-datasets:18.22.1'
 
   input:
   val(accession)

--- a/modules/local/fastp/main.nf
+++ b/modules/local/fastp/main.nf
@@ -1,7 +1,7 @@
 process FASTP {
   tag        "${meta.id}"
   label      "process_single"
-  container  'staphb/fastp:1.1.0'
+  container  'staphb/fastp:1.3.2'
 
   input:
   tuple val(meta), file(reads)

--- a/modules/local/freyja/main.nf
+++ b/modules/local/freyja/main.nf
@@ -1,7 +1,7 @@
 process FREYJA {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/freyja:2.0.3-SARS-CoV-2-03_22_2026-00-48-2026-03-23'
+  container     'staphb/freyja:2.0.3-SARS-CoV-2-04_19_2026-00-53-2026-04-20'
 
   input:
   tuple val(meta), file(bam), file(reference_genome)
@@ -51,7 +51,7 @@ process FREYJA {
 process FREYJA_AGGREGATE {
   tag        "Aggregating results from freyja"
   label      "process_single"
-  container  'staphb/freyja:2.0.3-SARS-CoV-2-03_22_2026-00-48-2026-03-23'
+  container  'staphb/freyja:2.0.3-SARS-CoV-2-04_19_2026-00-53-2026-04-20'
 
 
   input:

--- a/modules/local/iqtree/main.nf
+++ b/modules/local/iqtree/main.nf
@@ -1,7 +1,7 @@
 process IQTREE {
   tag        "Creating phylogenetic tree with iqtree"
   label      "process_high"
-  container  'staphb/iqtree3:3.0.1'
+  container  'staphb/iqtree3:3.1.1'
 
   input:
   file(msa)

--- a/modules/local/local/main.nf
+++ b/modules/local/local/main.nf
@@ -1,7 +1,7 @@
 //# some fastas are created with the header of >reference, so this changes the header
 process PREP {
   tag        "${fasta}"
-  container  'staphb/pandas:3.0.1'
+  container  'staphb/pandas:3.0.2'
   label      "process_single"
 
   input:
@@ -33,7 +33,7 @@ process PREP {
 process SUMMARY {
   tag        "Creating summary files"
   label      "process_low"
-  container  'staphb/pandas:3.0.1'
+  container  'staphb/pandas:3.0.2'
 
   input:
   tuple file(files), file(script), file(multiqc)
@@ -69,7 +69,7 @@ process SUMMARY {
 process UNZIP {
   tag        "unzipping nextclade dataset"
   label      "process_single"
-  container  'staphb/ncbi-datasets:18.18.0'
+  container  'staphb/ncbi-datasets:18.22.1'
 
   input:
   file(input)

--- a/modules/local/nextclade/main.nf
+++ b/modules/local/nextclade/main.nf
@@ -1,7 +1,7 @@
 process NEXTCLADE_DATASET {
   tag        "Downloading Nextclade Dataset"
   label      "process_medium"
-  container  'nextstrain/nextclade:3.21.0'
+  container  'nextstrain/nextclade:3.21.1'
 
   output:
   path "dataset", emit: dataset
@@ -38,7 +38,7 @@ process NEXTCLADE_DATASET {
 process NEXTCLADE {
   tag        "Clade Determination"
   label      "process_medium"
-  container  'nextstrain/nextclade:3.21.0'
+  container  'nextstrain/nextclade:3.21.1'
 
   input:
   file(fasta)

--- a/modules/local/samtools/main.nf
+++ b/modules/local/samtools/main.nf
@@ -1,7 +1,7 @@
 process SAMTOOLS_QC {
   tag        "${meta.id}"
   label      "process_single"
-  container  'staphb/samtools:1.23'
+  container  'staphb/samtools:1.23.1'
 
   input:
   tuple val(meta), file(bam)
@@ -75,7 +75,7 @@ process SAMTOOLS_QC {
 process SAMTOOLS_AMPLICONSTATS {
   tag        "${meta.id}"
   label      "process_single"
-  container  'staphb/samtools:1.23'
+  container  'staphb/samtools:1.23.1'
   errorStrategy 'ignore'
   
   input:
@@ -115,7 +115,7 @@ process SAMTOOLS_AMPLICONSTATS {
 process SAMTOOLS_PLOT_AMPLICONSTATS {
   tag           "${meta.id}"
   label         "process_single"
-  container     'staphb/samtools:1.23'
+  container     'staphb/samtools:1.23.1'
   // fails for empty samples
   errorStrategy 'ignore'
 
@@ -156,7 +156,7 @@ process SAMTOOLS_PLOT_AMPLICONSTATS {
 process SAMTOOLS_SORT {
   tag        "${meta.id}"
   label      "process_high"
-  container  'staphb/samtools:1.23'
+  container  'staphb/samtools:1.23.1'
 
   input:
   tuple val(meta), file(sam)
@@ -196,7 +196,7 @@ process SAMTOOLS_SORT {
 process SAMTOOLS_FILTER {
   tag        "${meta.id}"
   label      "process_single"
-  container  'staphb/samtools:1.23'
+  container  'staphb/samtools:1.23.1'
 
   input:
   tuple val(meta), file(sam)
@@ -239,7 +239,7 @@ process SAMTOOLS_FILTER {
 process SAMTOOLS_AMPLICONCLIP {
   tag        "${meta.id}"
   label      "process_single"
-  container  'staphb/samtools:1.23'
+  container  'staphb/samtools:1.23.1'
 
 
   input:
@@ -283,7 +283,7 @@ process SAMTOOLS_AMPLICONCLIP {
 process SAMTOOLS_MARKDUP {
   tag        "${meta.id}"
   label      "process_single"
-  container  'staphb/samtools:1.23'
+  container  'staphb/samtools:1.23.1'
 
   input:
   tuple val(meta), val(type), file(sam) 

--- a/nextflow.config
+++ b/nextflow.config
@@ -281,7 +281,7 @@ manifest {
   mainScript        = 'main.nf'
   defaultBranch     = 'master'
   nextflowVersion   = '>=24.04.4'
-  version           = 'v3.72.26090'
+  version           = 'v3.72.26112'
   doi               = ''
 }
 

--- a/subworkflows/local/consensus/main.nf
+++ b/subworkflows/local/consensus/main.nf
@@ -184,8 +184,15 @@ Relevant params and their values:
       ARTIC_FILTER(ch_nanopore)
       ch_versions = ch_versions.mix(ARTIC_FILTER.out.versions.first())
 
+      ARTIC_FILTER.out.filtered_nanopore_reads
+        .combine(ch_primer_bed)
+        .filter()
+        .map{ it -> it[-1] }
+        .unique()
+        .set { ch_nanopore_primer_bed }
+
       if (params.primer_bed) {
-        ARTIC_TOOLS(ch_primer_bed)
+        ARTIC_TOOLS(ch_nanopore_primer_bed)
         ch_versions = ch_versions.mix(ARTIC_TOOLS.out.versions.first())
         ch_primer = ARTIC_TOOLS.out.bed
       } else {

--- a/subworkflows/local/consensus/main.nf
+++ b/subworkflows/local/consensus/main.nf
@@ -184,11 +184,11 @@ Relevant params and their values:
       ARTIC_FILTER(ch_nanopore)
       ch_versions = ch_versions.mix(ARTIC_FILTER.out.versions.first())
 
-      ARTIC_FILTER.out.filtered_nanopore_reads
+      ARTIC_FILTER.out.fastq
         .combine(ch_primer_bed)
-        .filter()
+        .filter{it -> it[0]}
         .map{ it -> it[-1] }
-        .unique()
+        .first()
         .set { ch_nanopore_primer_bed }
 
       if (params.primer_bed) {


### PR DESCRIPTION
- updated freyja to 2.0.3-SARS-CoV-2-04_19_2026-00-53-2026-04-20
- updated nextclade to 3.21.1
- updated bbnorm to 39.81b
- update bcftools to 1.23.1
- update datasets to 18.22.1
- update fastp to 1.3.2
- update iqtree to 3.1.1
- update samtools to 1.23.1

- bug fix: only use artic tools when there are nanopore reads