### PR TITLE
3.72.26153

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,4 +1,4 @@
-version: "v.3.7.20230502"
+version: 1.2
 workflows:
   - name: Cecret
     subclass: NFL

--- a/modules/local/bbnorm/main.nf
+++ b/modules/local/bbnorm/main.nf
@@ -1,7 +1,7 @@
 process BBNORM {
     tag           "${meta.id}"
     label         'process_medium'
-    container     'staphb/bbtools:39.81b'
+    container     'staphb/bbtools:39.84'
 
 
     input:

--- a/modules/local/datasets/main.nf
+++ b/modules/local/datasets/main.nf
@@ -2,7 +2,7 @@ process DATASETS {
   tag           "${accession}"
   // because there's no way to specify threads
   label         "process_low"
-  container     'staphb/ncbi-datasets:18.23.0'
+  container     'staphb/ncbi-datasets:18.25.1'
 
   input:
   val(accession)

--- a/modules/local/fastp/main.nf
+++ b/modules/local/fastp/main.nf
@@ -1,7 +1,7 @@
 process FASTP {
   tag        "${meta.id}"
   label      "process_single"
-  container  'staphb/fastp:1.3.2'
+  container  'staphb/fastp:1.3.3'
 
   input:
   tuple val(meta), file(reads)

--- a/modules/local/freyja/main.nf
+++ b/modules/local/freyja/main.nf
@@ -1,7 +1,7 @@
 process FREYJA {
   tag           "${meta.id}"
   label         "process_medium"
-  container     'staphb/freyja:2.0.3-SARS-CoV-2-04_27_2026-00-55-2026-04-27'
+  container     'staphb/freyja:2.0.3-SARS-CoV-2-06_01_2026-01-12-2026-06-01'
 
   input:
   tuple val(meta), file(bam), file(reference_genome)
@@ -51,7 +51,7 @@ process FREYJA {
 process FREYJA_AGGREGATE {
   tag        "Aggregating results from freyja"
   label      "process_single"
-  container  'staphb/freyja:2.0.3-SARS-CoV-2-04_27_2026-00-55-2026-04-27'
+  container  'staphb/freyja:2.0.3-SARS-CoV-2-06_01_2026-01-12-2026-06-01'
 
 
   input:

--- a/modules/local/multiqc/main.nf
+++ b/modules/local/multiqc/main.nf
@@ -1,7 +1,7 @@
 process MULTIQC {
   tag        "multiqc"
   label      "process_single"
-  container  'staphb/multiqc:1.33'
+  container  'staphb/multiqc:1.34'
 
   input:
   file(input)

--- a/nextflow.config
+++ b/nextflow.config
@@ -286,7 +286,7 @@ manifest {
   mainScript        = 'main.nf'
   defaultBranch     = 'master'
   nextflowVersion   = '>=25.10.4'
-  version           = 'v3.72.26133'
+  version           = 'v3.72.26153'
   doi               = ''
 }
 


### PR DESCRIPTION
Closes https://github.com/UPHL-BioNGS/Cecret/issues/575
- update bbnorm to 39.84
- update datsets to 18.25.1
- update fastp to 1.3.3
- update freyja to 2.0.3-SARS-CoV-2-06_01_2026-01-12-2026-06-01
- multiqc to 1.34

- fixes dockstore yml / closes https://github.com/UPHL-BioNGS/Cecret/issues/574

Note: will need to find newer, higher coverage nanopore reads for testing