### PR TITLE
Add mailto: to the reporting email links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [eriny@utah.gov](eriny@utah.gov). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [eriny@utah.gov](mailto:eriny@utah.gov). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
 
 Further details of specific enforcement policies may be posted separately.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,4 +68,4 @@ We use the standard GitHub **fork and pull request** workflow.
 
 ## 🏛️ Code of Conduct
 
-Please note that this project is governed by a **Code of Conduct**. By participating, you are expected to uphold this code. Please report unacceptable behavior to [eriny@utah.gov](eriny@utah.gov).
+Please note that this project is governed by a **Code of Conduct**. By participating, you are expected to uphold this code. Please report unacceptable behavior to [eriny@utah.gov](mailto:eriny@utah.gov).


### PR DESCRIPTION
The email links in `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` are written as `[eriny@utah.gov](eriny@utah.gov)`, so GitHub renders them as relative links. Clicking one gives a 404 instead of opening a mail client.

Adds the `mailto:` scheme to both.